### PR TITLE
Reduce twice image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM ubuntu:14.04
+FROM debian:7
 
 MAINTAINER Chet Printhong
 
 RUN dpkg --add-architecture i386
-RUN apt-get update && apt-get install libstdc++5:i386 curl -y
+RUN apt-get update && apt-get install libstdc++5:i386 wget -y
 
 RUN mkdir /app
 WORKDIR /app
 
-RUN curl -O http://download.sopcast.com/download/sp-auth.tgz
+RUN wget http://download.sopcast.com/download/sp-auth.tgz && apt-get remove wget -y
 RUN tar -xf sp-auth.tgz
 
 ADD docker-entrypoint.sh /


### PR DESCRIPTION
Moving to `debian` and `wget` can reduce image size from 244.8 MB to 121.3 MB
`wget` takes ~4 MB, `curl` takes ~12 MB
